### PR TITLE
Add function to Set target price to dynamic auction algo

### DIFF
--- a/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
@@ -198,6 +198,16 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
      * @notice Set the auction target price.
      * @dev Only callable by the owner.
      */
+    function setTargetPrice(uint256 _targetPrice) external override onlyOwner {
+        targetPrice = _targetPrice;
+
+        emit AuctionTargetPriceUpdated(_targetPrice);
+    }
+
+    /**
+     * @notice Set the auction target price.
+     * @dev Only callable by the owner.
+     */
     function setTargetPrice(uint256 _targetPrice) external onlyOwner {
         targetPrice = _targetPrice;
     }


### PR DESCRIPTION
Adds the setTargetPrice function to enable the owner of the contract to set the target price for auctions.

If an auction's salePrice is below the target price, the duration of the next auction will increase.

If an auction's salePrice is above the target price, the duration of the next auction will decrease.

(used @spatializes [initial version of the auction algorithm](https://github.com/ATXDAO/nouns-monorepo/pull/41) as a base)