### PR TITLE
Issue 38 changes

### DIFF
--- a/packages/nouns-contracts/contracts/NounsToken.sol
+++ b/packages/nouns-contracts/contracts/NounsToken.sol
@@ -106,7 +106,7 @@ contract NounsToken is INounsToken, Ownable, ERC721Checkpointable {
         INounsDescriptorMinimal _descriptor,
         INounsSeeder _seeder,
         IProxyRegistry _proxyRegistry
-    ) ERC721('Nouns', 'NOUN') {
+    ) ERC721('ATXNouns', 'ATX') {
         noundersDAO = _noundersDAO;
         minter = _minter;
         descriptor = _descriptor;

--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times-daov1.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times-daov1.ts
@@ -19,7 +19,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    5120000000000000 /* 1 wei */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-and-configure-short-times.ts
+++ b/packages/nouns-contracts/tasks/deploy-and-configure-short-times.ts
@@ -19,7 +19,7 @@ task(
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    5120000000000000 /* 1 wei */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-local.ts
+++ b/packages/nouns-contracts/tasks/deploy-local.ts
@@ -24,7 +24,7 @@ interface Contract {
 task('deploy-local', 'Deploy contracts to hardhat')
   .addOptionalParam('noundersdao', 'The nounders DAO contract address')
   .addOptionalParam('auctionTimeBuffer', 'The auction time buffer (seconds)', 30, types.int) // Default: 30 seconds
-  .addOptionalParam('auctionReservePrice', 'The auction reserve price (wei)', 1, types.int) // Default: 1 wei
+  .addOptionalParam('auctionReservePrice', 'The auction reserve price (wei)', 5120000000000000, types.int) // Default: 1 wei
   .addOptionalParam(
     'auctionMinIncrementBidPercentage',
     'The auction min increment bid percentage (out of 100)', // Default: 5%

--- a/packages/nouns-contracts/tasks/deploy-short-times-daov1.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times-daov1.ts
@@ -36,7 +36,7 @@ task('deploy-short-times-daov1', 'Deploy all Nouns contracts with short gov time
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    5120000000000000 /* 1 wei */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy-short-times.ts
+++ b/packages/nouns-contracts/tasks/deploy-short-times.ts
@@ -36,7 +36,7 @@ task('deploy-short-times', 'Deploy all Nouns contracts with short gov times for 
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    5120000000000000 /* 1 wei */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-contracts/tasks/deploy.ts
+++ b/packages/nouns-contracts/tasks/deploy.ts
@@ -36,7 +36,7 @@ task('deploy', 'Deploys NFTDescriptor, NounsDescriptor, NounsSeeder, and NounsTo
   .addOptionalParam(
     'auctionReservePrice',
     'The auction reserve price (wei)',
-    1 /* 1 wei */,
+    5120000000000000 /* 1 wei */,
     types.int,
   )
   .addOptionalParam(

--- a/packages/nouns-webapp/src/components/AuctionActivityNounTitle/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivityNounTitle/index.tsx
@@ -7,7 +7,7 @@ const AuctionActivityNounTitle: React.FC<{ nounId: BigNumber; isCool?: boolean }
   return (
     <div className={classes.wrapper}>
       <h1 style={{ color: isCool ? 'var(--brand-cool-dark-text)' : 'var(--brand-warm-dark-text)' }}>
-        <Trans>Noun {nounId.toString()}</Trans>
+        <Trans>ATX Noun {nounId.toString()}</Trans>
       </h1>
     </div>
   );

--- a/packages/nouns-webapp/src/components/AuctionActivityNounTitle/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivityNounTitle/index.tsx
@@ -7,7 +7,10 @@ const AuctionActivityNounTitle: React.FC<{ nounId: BigNumber; isCool?: boolean }
   return (
     <div className={classes.wrapper}>
       <h1 style={{ color: isCool ? 'var(--brand-cool-dark-text)' : 'var(--brand-warm-dark-text)' }}>
-        <Trans>ATX Noun {nounId.toString()}</Trans>
+       ATX NOUN {nounId.toString()}
+      {/* <Trans>ATX Noun {nounId.toString()}</Trans> */}
+        {/* <Trans>{nounId.toString()}</Trans> */}
+
       </h1>
     </div>
   );


### PR DESCRIPTION
Changes referenced from: [Issue 38](https://github.com/ATXDAO/nouns-monorepo/issues/38)
- [x] DAO Name: ATX Nouns (completed as long as this means the same thing as NFT collection name)
- [x] DAO Symbol: $ATX (completed as long as this means the same thing as NFT collection symbol)
- [ ] Auction duration: 3 days (hold off on setting this one until launch so we can keep it short during testing)
- [x] Auction reserve price: 0.00512 ETH
- [x] Name of the NFT displayed in the Auction UI should be "ATX Noun #"
- [ ] Replace "Nouns" with "ATXNouns" in all of the contract names (Will require some big changes that are worthy of creating a seperate issue and PR).

The contracts HAVE NOT been redeployed as @spatializes is more familiar with the process so I will let him take the reins on doing so. Thus, even though these changes have been made on the repository, it may not fully reflect what you see until we actually do the full redeployment process.