### PR TITLE
allows and displays 5 decimal places for bidding

### DIFF
--- a/packages/nouns-webapp/src/components/Bid/index.tsx
+++ b/packages/nouns-webapp/src/components/Bid/index.tsx
@@ -98,7 +98,7 @@ const Bid: React.FC<{
     const input = event.target.value;
 
     // disable more than 2 digits after decimal point
-    if (input.includes('.') && event.target.value.split('.')[1].length > 2) {
+    if (input.includes('.') && event.target.value.split('.')[1].length > 5) {
       return;
     }
 
@@ -275,7 +275,6 @@ const Bid: React.FC<{
             <FormControl
               className={classes.bidInput}
               type="number"
-              min="0"
               onChange={bidInputHandler}
               ref={bidInputRef}
               value={bidInput}

--- a/packages/nouns-webapp/src/components/CurrentBid/CurrentBid.module.css
+++ b/packages/nouns-webapp/src/components/CurrentBid/CurrentBid.module.css
@@ -13,7 +13,7 @@
 .section h2 {
   font-family: 'Calistoga';
   font-weight: bold;
-  font-size: 32px;
+  font-size: 28px;
   margin-bottom: 0px !important;
   margin-top: 3px;
 }
@@ -40,6 +40,7 @@
 
   .currentBid {
     margin-right: 0.5rem;
+    font-size: 12px;
   }
 
   .wrapper {

--- a/packages/nouns-webapp/src/components/TruncatedAmount/index.tsx
+++ b/packages/nouns-webapp/src/components/TruncatedAmount/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 const TruncatedAmount: React.FC<{ amount: BigNumber }> = props => {
   const { amount } = props;
 
-  const eth = new BigNumber(utils.formatEther(amount.toString())).toFixed(2);
+  const eth = new BigNumber(utils.formatEther(amount.toString())).toFixed(5);
   return <>Ξ {`${eth}`}</>;
 };
 export default TruncatedAmount;


### PR DESCRIPTION
References: [Issue 52](https://github.com/ATXDAO/nouns-monorepo/issues/52)

- [x] Current bid and bid history display up to 3 decimal places
_Displays up to 5 decimal places. May add an option to display 5 on testnets and 3 on mainnets or switch entire app to 3 when we hit mainnet._
- [x] Users can input up to 3 decimal places when placing a bid